### PR TITLE
html page download exception

### DIFF
--- a/apache_downloader/downloader.py
+++ b/apache_downloader/downloader.py
@@ -43,6 +43,12 @@ def get_hash(path, site="www"):
     req.raise_for_status()
     dl_hash = "".join(req.text.split()).lower().strip()  # sometimes the hash is multi-line and chunked
     dl_hash = dl_hash.split(":")[-1]  # sometimes the hash begins with the file name + ":"
+
+    if "<html>" in (dl_hash) or "</html>" in (dl_hash):     
+        # Throw exception for html page.
+        requests.get("http://httpbin.org/status/404")\
+            .raise_for_status()
+    
     logging.debug("Expected hash is {hash}".format(hash=dl_hash))
     return dl_hash
 

--- a/apache_downloader/downloader.py
+++ b/apache_downloader/downloader.py
@@ -30,7 +30,7 @@ def get_mirror_url(path, site="www"):
     }[site]
 
 
-def get_hash(path, site="www"):
+def get_hash(path, site):
     """
     Get the hash value from the official apache.org website
     :param path: the download file path, e.g. /nifi/nifi-registry/nifi-registry-0.5.0/nifi-registry-0.5.0-bin.tar.gz
@@ -43,12 +43,6 @@ def get_hash(path, site="www"):
     req.raise_for_status()
     dl_hash = "".join(req.text.split()).lower().strip()  # sometimes the hash is multi-line and chunked
     dl_hash = dl_hash.split(":")[-1]  # sometimes the hash begins with the file name + ":"
-
-    if "<html>" in (dl_hash) or "</html>" in (dl_hash):     
-        # Throw exception for html page.
-        requests.get("http://httpbin.org/status/404")\
-            .raise_for_status()
-    
     logging.debug("Expected hash is {hash}".format(hash=dl_hash))
     return dl_hash
 
@@ -73,7 +67,7 @@ def download_and_verify(path, destination=None):
         download_path = destination
         logging.info("Downloading Apache project {path}".format(path=path))
 
-    site = "www"
+    site = "downloads"
     try:
         expected_hash = get_hash(path, site)
     except requests.exceptions.HTTPError:


### PR DESCRIPTION
## Reason
- Downloader fails to download archived `sha256` files.

## What's changed
- Check if we are downloading a html page instead of `sha256`

## Test

![image](https://github.com/jasonrig/apache_downloader/assets/102934581/7d7b13c2-758a-4313-b242-2ab31fc370ae)
